### PR TITLE
fix: type import of kotlinx-serialization-json

### DIFF
--- a/http4k/pom.xml
+++ b/http4k/pom.xml
@@ -28,7 +28,6 @@
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-serialization-json</artifactId>
       <version>${kotlinx-serialization.version}</version>
-      <type>pom</type>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Should type pom be used for this dependency, or is it only ment for importing boms in dependencyManagement?

Not certain, but this seems to make changes to dependencyManagement for consumers. 